### PR TITLE
fix(ui): resolve num_gpus error

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ First, clone the repository in your local machine. Within the repository, create
 
 ```
 python -m venv .venv
+source .venv/bin/activate
 ```
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Fully theory. Simulation based models available.
 
 ## Usage
 
+First, clone the repository in your local machine. Within the repository, create a virtual environment to ensure no conflicts in dependencies.
+
+```
+python -m venv .venv
+```
+
 ### Install
 ```
 make install
@@ -54,9 +60,10 @@ Now, build a regression model using this data, using the provided make target:
 ```
 make build-model
 ```
-This will create a model called `./workdir/model.json`.
+This will create a model called `./workdir/model.json` which will be used to estimate the resource consumption.
 
 You can now run the estimator, using one of the various UIs.
+
 
 ### Interacting
 
@@ -64,7 +71,7 @@ For a full list of UIs, look into the `./fm_training_estimator/ui` folder.
 
 Easiest option is to run the Web UI.
 
-To do this, first prepare a txt file called `model_whitelist.txt` in the `workdir/` with a list of model names, 1 per line. You can use the provided example listing using:
+To do this, first prepare a txt file called `model_whitelist.txt` in the `workdir/` with a list of model names, 1 per line. Note that these are the models on which you want to run the estimator to estimate their resource consumption. You can use the provided example listing using:
 ```
 cp ./fm_training_estimator/ui/model_whitelist.txt ./workdir/
 ```

--- a/fm_training_estimator/ui/core.py
+++ b/fm_training_estimator/ui/core.py
@@ -28,7 +28,7 @@ def run(config, lookup_data_path=None, model_path=None):
     res["model_memory"] = fmt_size(res["model_memory_og"])
     res["optimizer_memory"] = fmt_size(res["optimizer_memory_og"])
 
-    ia.numGpusPerPod = ia.numGpusPerPod
+    res["num_gpus"] = ia.numGpusPerPod
 
     if ia.numGpusPerPod == 0:
         if fm.technique == "full" and is_fsdp(ta):

--- a/fm_training_estimator/ui/core.py
+++ b/fm_training_estimator/ui/core.py
@@ -28,6 +28,8 @@ def run(config, lookup_data_path=None, model_path=None):
     res["model_memory"] = fmt_size(res["model_memory_og"])
     res["optimizer_memory"] = fmt_size(res["optimizer_memory_og"])
 
+    ia.numGpusPerPod = ia.numGpusPerPod
+
     if ia.numGpusPerPod == 0:
         if fm.technique == "full" and is_fsdp(ta):
             res["num_gpus"] = est.fsdp_est.get_number_of_gpus()


### PR DESCRIPTION
When num_gpus was set to be > 0, there was a 'key not found' error in the estimator UI. 
Fixed this by changing core.py in ui.

Also, updated the README to include venv creation and clarification on model_whitelist.txt