### PR TITLE
build: Add a simple launch script and Dockerfile to build reference image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,85 @@
-FROM python:3.11 AS builder
-SHELL ["/bin/bash", "-c"]
-WORKDIR /app
-COPY requirements.txt requirements.txt
-RUN python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
-COPY . .
-RUN source .venv/bin/activate && pip install .
+## Global Args #################################################################
+ARG BASE_UBI_IMAGE_TAG=latest
+ARG USER=tuning
+ARG USER_UID=1000
+ARG PYTHON_VERSION=3.11
+ARG WHEEL_VERSION=""
 
-FROM python:3.11 AS runner
-SHELL ["/bin/bash", "-c"]
+## Base Layer ##################################################################
+FROM registry.access.redhat.com/ubi9/ubi:${BASE_UBI_IMAGE_TAG} AS base
+
+ARG PYTHON_VERSION
+ARG USER
+ARG USER_UID
+
+# Note this works for 3.9, 3.11, 3.12
+RUN dnf remove -y --disableplugin=subscription-manager \
+        subscription-manager \
+    && dnf install -y python${PYTHON_VERSION} procps g++ python${PYTHON_VERSION}-devel \
+    && ln -s /usr/bin/python${PYTHON_VERSION} /bin/python \
+    && python -m ensurepip --upgrade \
+    && python -m pip install --upgrade pip \
+    && python -m pip install --upgrade setuptools \
+    && dnf update -y \
+    && dnf clean all
+
+RUN useradd -u $USER_UID ${USER} -m -g 0 --system && \
+    chmod g+rx /home/${USER}
+
+FROM base AS python-installations
+
+ARG WHEEL_VERSION
+ARG USER
+ARG USER_UID
+
+RUN dnf install -y git && \
+    # perl-Net-SSLeay.x86_64 and server_key.pem are installed with git as dependencies
+    # Twistlock detects it as H severity: Private keys stored in image
+    rm -f /usr/share/doc/perl-Net-SSLeay/examples/server_key.pem && \
+    dnf clean all
+
+USER ${USER}
+WORKDIR /tmp
+RUN --mount=type=cache,target=/home/${USER}/.cache/pip,uid=${USER_UID} \
+    python -m pip install --user build
+COPY --chown=${USER}:root fm_training_estimator fm_training_estimator
+COPY .git .git
+COPY pyproject.toml pyproject.toml
+
+# Build a wheel if PyPi wheel_version is empty else download the wheel from PyPi
+RUN if [[ -z "${WHEEL_VERSION}" ]]; \
+    then python -m build --wheel --outdir /tmp; \
+    else pip download fm_training_estimator==${WHEEL_VERSION} --dest /tmp --only-binary=:all: --no-deps; \
+    fi && \
+    ls /tmp/*.whl >/tmp/bdist_name
+
+# Install from the wheel
+RUN --mount=type=cache,target=/home/${USER}/.cache/pip,uid=${USER_UID} \
+    python -m pip install --user wheel && \
+    python -m pip install --user "$(head bdist_name)" && \
+    # Cleanup the bdist whl file
+    rm $(head bdist_name) /tmp/bdist_name
+
+## Final image ################################################
+FROM base AS release
+ARG USER
+ARG PYTHON_VERSION
+
+RUN mkdir -p /licenses
+COPY LICENSE /licenses/
+
+RUN mkdir /app && \
+    chown -R $USER:0 /app /tmp && \
+    chmod -R g+rwX /app /tmp
+
+
+# Copy scripts and default configs
+COPY launch_estimator.py /app/
+RUN chmod +x /app/launch_estimator.py
+
 WORKDIR /app
-COPY --from=builder /app/.venv /app/.venv
-COPY workdir/model.json model.json
-COPY workdir/data.csv data.csv
-ENV VIRTUAL_ENV="/app/.venv"
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-CMD ["python3", "-m", "fm_training_estimator.ui.cli", "--model_path", "model.json", "--lookup_data_path", "data.csv", "input.json"]
+USER ${USER}
+COPY --from=python-installations /home/${USER}/.local /home/${USER}/.local
+ENV PYTHONPATH="/home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages"
+
+CMD [ "python", "/app/launch_estimator.py" ]

--- a/fm_training_estimator/config/arguments.py
+++ b/fm_training_estimator/config/arguments.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import List, Optional
 
 # Third Party
+from dataclass_wizard import JSONWizard
 from peft.tuners.lora import LoraConfig
 from peft.tuners.prompt_tuning import PromptTuningConfig
 from transformers import TrainingArguments
@@ -196,7 +197,7 @@ class JobConfig:
 
 
 @dataclass
-class EstimateInput:
+class EstimateInput(JSONWizard):
     """
     The dataclass that is an input to a estimate function.
     It includes a list of different training job configs and metadata about the estimator.

--- a/launch_estimator.py
+++ b/launch_estimator.py
@@ -1,0 +1,129 @@
+# Copyright The FM Training Estimator Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script wraps fm_training_estimator to run with user provided training configs.
+The script will read configuration via environment variable `ESTIMATOR_INPUT_JSON_PATH`
+for the path to the JSON config file or `ESTIMATOR_INPUT_JSON_ENV_VAR`
+for the encoded config string to parse.
+"""
+
+# Standard
+import base64
+import os
+import logging
+import pickle
+import subprocess
+import sys
+import traceback
+import json
+from pathlib import Path
+
+# Local
+from fm_training_estimator.config.arguments import DataArguments, EstimateInput, EstimatorMetadata, FMArguments, HFTrainingArguments, InfraArguments, JobConfig
+from fm_training_estimator.sdk import (
+    estimate_cost,
+    estimate_memory,
+    estimate_time,
+    estimate_tokens,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+def main():
+    ##########
+    #
+    # Parse arguments
+    #
+    ##########
+    try:
+        input_dict = get_input_dict()
+        logging.info("estimator launch parsed input json: %s", input_dict)
+        if not input_dict:
+            raise ValueError(
+                "Must set environment variable 'ESTIMATOR_INPUT_JSON_PATH'\
+            or 'ESTIMATOR_INPUT_JSON_ENV_VAR'."
+            )
+
+    except FileNotFoundError as e:
+        logging.error(traceback.format_exc())
+        sys.exit(1)
+    except (TypeError, ValueError, EnvironmentError) as e:
+        logging.error(traceback.format_exc())
+        sys.exit(1)
+    except Exception as e:  # pylint: disable=broad-except
+        logging.error(traceback.format_exc())
+        sys.exit(1)
+
+    ##########
+    #
+    # Run the estimator
+    #
+    ##########
+    model_path = os.getenv("ESTIMATOR_MODEL_PATH")
+    estimator_input = EstimateInput.from_dict(input_dict)
+    print("\n" * 3) 
+    print("Estimating Memory:....\n")
+
+    print("With only theory: ", estimate_memory(estimator_input))
+    if model_path:
+        print("With reg model: ", estimate_memory(estimator_input, model_path))
+
+    print("\n" * 3)
+    print("Estimating Time:....\n")
+
+    print("With only theory: ", estimate_time(estimator_input))
+    if model_path:
+        print("With reg model: ", estimate_time(estimator_input, model_path))
+    return 0
+
+def get_input_dict():
+    """Parses JSON configuration if provided via environment variables
+    ESTIMATOR_INPUT_JSON_ENV_VAR or ESTIMATOR_INPUT_JSON_PATH.
+
+    ESTIMATOR_INPUT_JSON_ENV_VAR is the base64 encoded JSON.
+    ESTIMATOR_INPUT_JSON_PATH is the path to the JSON config file.
+
+    Returns: dict or {}
+    """
+    json_env_var = os.getenv("ESTIMATOR_INPUT_JSON_ENV_VAR")
+    json_path = os.getenv("ESTIMATOR_INPUT_JSON_PATH")
+
+    # accepts either path to JSON file or encoded string config
+    # env var takes precedent
+    input_dict = {}
+    if json_env_var:
+        input_dict = txt_to_obj(json_env_var)
+    elif json_path:
+        with open(json_path, "r", encoding="utf-8") as f:
+            input_dict = json.load(f)
+
+    return input_dict
+
+def txt_to_obj(txt):
+    """Given encoded byte string, converts to base64 decoded dict.
+
+    Args:
+        txt: str
+    Returns: dict[str, Any]
+    """
+    base64_bytes = txt.encode("ascii")
+    message_bytes = base64.b64decode(base64_bytes)
+    try:
+        # If the bytes represent JSON string
+        return json.loads(message_bytes)
+    except UnicodeDecodeError:
+        # Otherwise the bytes are a pickled python dictionary
+        return pickle.loads(message_bytes)
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "scikit-learn",
   "gradio",
   "datasets",
+  "dataclass-wizard",
   "uvicorn"
 ]
 


### PR DESCRIPTION
This PR:
- adds a simple launch script that reads estimator input as a json value or file path, then runs estimate memory and time
- adds layers in Dockerfile to build from RedHat UBI base image, build a wheel, install the wheel, and run the above launch script.

Example usage of building/running image:
- Create a `my_input.json` inside `workdir` (assuming you also have `model.json` and `data.csv` in `workdir`):
```json
{
  "job_configs": [{
      "fm": {
        "base_model_path": "ibm-granite/granite-7b-base",
        "torch_dtype": "bfloat16",
        "block_size": 1024
      },
      "hf_training": {
        "per_device_train_batch_size": 1,
        "gradient_checkpointing": false
      },
      "data": {
        "dataset": "imdb",
        "te_approach": 0
      },
      "infra": {
        "numGpusPerPod": 1
      }
    }
  ],
  "estimator_metadata": {
    "base_data_path": "workdir/data.csv"
  }
}
```

- With this PR, you can build the image with:
```
docker build --progress=plain -t fm_training_estimator:release .
```

- And run the image mounting the `workdir` as a volume:
```
docker run --rm -d -e ESTIMATOR_INPUT_JSON_PATH=workdir/my_input.json  -v $(pwd)/workdir:/app/workdir/ --name estimator fm_training_estimator:release
```
While the container is alive/running, you can see the logs:
```
% docker logs estimator -f   
INFO:root:estimator launch parsed input json: {'job_configs': [{'fm': {'base_model_path': 'ibm-granite/granite-7b-base', 'torch_dtype': 'bfloat16', 'block_size': 1024}, 'hf_training': {'per_device_train_batch_size': 1, 'gradient_checkpointing': False}, 'data': {'dataset': 'imdb', 'te_approach': 0}, 'infra': {'numGpusPerPod': 1}}], 'estimator_metadata': {'base_data_path': 'workdir/data.csv'}}
INFO:root:Hybrid Estimator: Initializing
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.




Estimating Memory:....

With only theory:  MemoryEstimate(total_mem_estimate='58.2 GiB', activation_memory='9.2 GiB', gradient_memory='12.2 GiB', model_memory='12.2 GiB', optimizer_memory='24.5 GiB', num_gpus=1)




Estimating Time:....

Generating train split: 100%|██████████| 25000/25000 [00:00<00:00, 160888.94 examples/s]
Generating test split: 100%|██████████| 25000/25000 [00:00<00:00, 175531.49 examples/s]
Generating unsupervised split: 100%|██████████| 50000/50000 [00:00<00:00, 196052.86 examples/s]
INFO:root:Loading data in dataset...
100%|██████████| 25000/25000 [00:00<00:00, 41518.18it/s]
With only theory:  TimeEstimate(time=25000.0)
```