### PR TITLE
fix: sdk was not using lookup data

### DIFF
--- a/fm_training_estimator/config/arguments.py
+++ b/fm_training_estimator/config/arguments.py
@@ -29,7 +29,7 @@ class PeftLoraConfig:
 
     lora_alpha: int = field(default=8)
     lora_dropout: float = field(default=0.1)
-    target_modules: str = field(default="[q_proj, v_proj]")
+    target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
 
 
 @dataclass

--- a/fm_training_estimator/memory/lora/hybrid.py
+++ b/fm_training_estimator/memory/lora/hybrid.py
@@ -117,3 +117,4 @@ class HybridLoraEstimator:
         # No fall back here
         # If we reach here, we don't have a memory estimate
         logger.warning("Could not estimate memory by Hybrid Lora Estimator")
+        return 0

--- a/fm_training_estimator/memory/lora/hybrid.py
+++ b/fm_training_estimator/memory/lora/hybrid.py
@@ -114,7 +114,12 @@ class HybridLoraEstimator:
 
             return act
 
-        # No fall back here
-        # If we reach here, we don't have a memory estimate
-        logger.warning("Could not estimate memory by Hybrid Lora Estimator")
-        return 0
+        # If we reach here, we are falling back on theory
+        size = (
+            self.calculate_activation_memory()
+            + self.lora_est.calculate_gradient_memory()
+            + self.lora_est.calculate_model_memory()
+            + self.lora_est.calculate_optimizer_memory()
+        )
+
+        return size

--- a/fm_training_estimator/memory/lora/hybrid.py
+++ b/fm_training_estimator/memory/lora/hybrid.py
@@ -21,7 +21,7 @@ class HybridLoraEstimator:
         model_path,
     ):
 
-        logger.info("HybridLora Estimator: Initializing")
+        logger.info("Initializing")
 
         self.fm = fm_args
         self.ta = train_args

--- a/fm_training_estimator/memory/lora/hybrid.py
+++ b/fm_training_estimator/memory/lora/hybrid.py
@@ -87,13 +87,14 @@ class HybridLoraEstimator:
         }
 
         if self.lookup_est is not None:
-            logging.info("HybridLora: attempting lookup")
             lookup_query = format_query(
                 lookup_query_base, self.lookup_est.get_data_format()
             )
+            logging.debug("HybridLora: lookup_query is: %s", lookup_query)
             res = self.lookup_est.run(lookup_query)
             if res.empty:
                 lookup_mem = None
+                logging.debug("Lookup: no match found by lookup")
             else:
                 lookup_mem = res["memory"][0:1].item()
             if lookup_mem is not None:
@@ -111,3 +112,5 @@ class HybridLoraEstimator:
             return act
 
         # No fall back here
+        # If we reach here, we don't have a memory estimate
+        logging.warning("Could not estimate memory by Hybrid Lora Estimator")

--- a/fm_training_estimator/memory/lora/lora.py
+++ b/fm_training_estimator/memory/lora/lora.py
@@ -8,6 +8,10 @@ from ...config import FMArguments, HFTrainingArguments, PeftLoraConfig
 from ...utils import fmt_size, get_size_from_precision
 from ..full import FullParameterTuningEstimator
 
+# Standard
+import logging
+
+logger = logging.getLogger("LoRA_EST")
 
 class LoraEstimator(FullParameterTuningEstimator):
     def __init__(
@@ -26,6 +30,7 @@ class LoraEstimator(FullParameterTuningEstimator):
             modelc = AutoConfig.from_pretrained(self.fm_args.base_model_path)
             model = AutoModelForCausalLM.from_config(modelc)
 
+        logger.info("Initializing LoraEstimator with lora args %s", self.lora_args)
         self.peft_model = get_peft_model(model, LoraConfig(self.lora_args))
 
         self.num_of_trainable_params = self.peft_model.num_parameters(

--- a/fm_training_estimator/memory/lora/lora.py
+++ b/fm_training_estimator/memory/lora/lora.py
@@ -1,3 +1,6 @@
+# Standard
+import logging
+
 # Third Party
 from accelerate import init_empty_weights
 from peft import LoraConfig, get_peft_model
@@ -8,10 +11,8 @@ from ...config import FMArguments, HFTrainingArguments, PeftLoraConfig
 from ...utils import fmt_size, get_size_from_precision
 from ..full import FullParameterTuningEstimator
 
-# Standard
-import logging
-
 logger = logging.getLogger("LoRA_EST")
+
 
 class LoraEstimator(FullParameterTuningEstimator):
     def __init__(
@@ -31,7 +32,15 @@ class LoraEstimator(FullParameterTuningEstimator):
             model = AutoModelForCausalLM.from_config(modelc)
 
         logger.info("Initializing LoraEstimator with lora args %s", self.lora_args)
-        self.peft_model = get_peft_model(model, LoraConfig(self.lora_args))
+        self.peft_model = get_peft_model(
+            model,
+            LoraConfig(
+                r=self.lora_args.r,
+                lora_alpha=self.lora_args.lora_alpha,
+                lora_dropout=self.lora_args.lora_dropout,
+                target_modules=self.lora_args.target_modules,
+            ),
+        )
 
         self.num_of_trainable_params = self.peft_model.num_parameters(
             only_trainable=True

--- a/fm_training_estimator/sdk/sdk.py
+++ b/fm_training_estimator/sdk/sdk.py
@@ -1,3 +1,6 @@
+# Standard
+import logging
+
 # First Party
 from fm_training_estimator.config.arguments import (
     CostEstimate,
@@ -16,13 +19,12 @@ from fm_training_estimator.tokens.te0.te0 import TokenEstimator0
 from ..config import is_fsdp
 from ..utils import fmt_size
 
-#Standard
-import logging
-
-logger = logging.getLogger("ESTIMATOR")
+logger = logging.getLogger("EST_SDK")
 
 
-def _get_hybrid_estimator(conf: JobConfig, model_path: str = None, lookup_data_path: str = None):
+def _get_hybrid_estimator(
+    conf: JobConfig, model_path: str = None, lookup_data_path: str = None
+):
     if conf.fm.technique == "lora":
         return HybridLoraEstimator(
             conf.fm,
@@ -33,7 +35,9 @@ def _get_hybrid_estimator(conf: JobConfig, model_path: str = None, lookup_data_p
             model_path,
         )
     else:
-        return HybridEstimator(conf.fm, conf.hf_training, conf.infra, lookup_data_path, model_path)
+        return HybridEstimator(
+            conf.fm, conf.hf_training, conf.infra, lookup_data_path, model_path
+        )
 
 
 def estimate_memory(
@@ -60,7 +64,9 @@ def estimate_memory(
     if estimate_input.estimator_metadata:
         lookup_data_path = estimate_input.estimator_metadata.base_data_path
     if lookup_data_path is None:
-        logger.warning("No lookup data path given. Set it via estimator_metadata.base_data_path in input json. Proceeding with estimator with limited lookup ability.")
+        logger.warning(
+            "No lookup data path given. Set it via estimator_metadata.base_data_path in input json. Proceeding with estimator with limited lookup ability."
+        )
 
     est = _get_hybrid_estimator(job_config, model_path, lookup_data_path)
 
@@ -162,7 +168,9 @@ def estimate_time(
     if estimate_input.estimator_metadata:
         lookup_data_path = estimate_input.estimator_metadata.base_data_path
     if lookup_data_path is None:
-        logger.warning("No lookup data path given. Set it via estimator_metadata.base_data_path in input json. Proceeding with estimator with limited lookup ability.")
+        logger.warning(
+            "No lookup data path given. Set it via estimator_metadata.base_data_path in input json. Proceeding with estimator with limited lookup ability."
+        )
 
     _, time = _estimate_tokens_and_time(
         job_config, model_path, estimate_input.estimator_metadata.base_data_path
@@ -194,7 +202,9 @@ def estimate_tokens(
     if estimate_input.estimator_metadata:
         lookup_data_path = estimate_input.estimator_metadata.base_data_path
     if lookup_data_path is None:
-        logger.warning("No lookup data path given. Set it via estimator_metadata.base_data_path in input json. Proceeding with estimator with limited lookup ability.")
+        logger.warning(
+            "No lookup data path given. Set it via estimator_metadata.base_data_path in input json. Proceeding with estimator with limited lookup ability."
+        )
 
     tps, _ = _estimate_tokens_and_time(
         job_config, model_path, estimate_input.estimator_metadata.base_data_path


### PR DESCRIPTION
- The `_get_hybrid_estimator` function in `sdk.py` was only using None for `lookup_data_path`. This PR fixes to use the data path user passes in from input.
- This PR also explicitly set the lora args in LoraEstimator as it didn't work before and none of the lora values user set was passed in.
- Add a new logger called `HBR_LoRA_EST` for the Hybrid Lora Memory Estimator for logging readability, same for logger `LoRA_EST` for the Lora Estimator.