### PR TITLE
Feature: v1 of modeling other time components

### DIFF
--- a/fm_training_estimator/sdk/sdk.py
+++ b/fm_training_estimator/sdk/sdk.py
@@ -151,7 +151,7 @@ def _estimate_tokens_and_time(
             tps = 1
 
         # calculate full time here
-        time = get_total_time(tps, total_tokens)
+        time = get_total_time(conf.hf_training, conf.infra, token_est, tps, total_tokens)
     else:
         # logger.warn("Could not get a total tokens to calculate time, setting time to 0.")
         time = 0

--- a/fm_training_estimator/sdk/sdk.py
+++ b/fm_training_estimator/sdk/sdk.py
@@ -15,6 +15,7 @@ from fm_training_estimator.memory.lora.hybrid import HybridLoraEstimator
 from fm_training_estimator.memory.qlora.hybrid import HybridQLoraEstimator
 from fm_training_estimator.throughput.hybrid.hybrid import HybridSpeedEstimator
 from fm_training_estimator.tokens.te0.te0 import TokenEstimator0
+from fm_training_estimator.time import get_total_time
 
 # Local
 from ..config import is_fsdp
@@ -149,7 +150,8 @@ def _estimate_tokens_and_time(
             # logger.warn("Could not calculate tps, defaulting to 1.")
             tps = 1
 
-        time = total_tokens / tps
+        # calculate full time here
+        time = get_total_time(tps, total_tokens)
     else:
         # logger.warn("Could not get a total tokens to calculate time, setting time to 0.")
         time = 0

--- a/fm_training_estimator/time/README.md
+++ b/fm_training_estimator/time/README.md
@@ -1,0 +1,32 @@
+# Time
+
+Time taken for a training job consists for two main sub components:
+
+1. Training time: actual time spent in the training process - forward pass, backward pass and so on.
+2. Non-training time: other significant sources of times such as model load, model save etc.
+
+## Training time
+
+Training time is calculated in the estimator as a simple combination of two inputs:
+
+1. `throughput`: that is number of tokens per second achieved by the training script.
+2. `tokens`: the number of tokens to be processed for the given dataset under the given conditions.
+
+Refer to the subcomponents in `../throughput` and `../tokens` for these calculations. Once we have both of these, a simple trivial division gives us the training time - albeit for a single epoch.
+
+## Non-training time
+
+This is made of the following components.
+
+### Model load
+
+In the beginning, a model must be loaded from disk, usually from files in Pytorch model formats or Hugging Face SafeTensor formats. This model may possibly fetched from the Hugging Face Hub, or available already on disk, cached or a from a local checkpoint format.
+
+### Dataload time
+
+Time take to load a dataset from files (typically json, jsonl or parquet) on disk.
+
+### Checkpoint time
+
+Every k steps or l epochs, a checkpoint may be saved to disk. There is a lot of research in this topic, to make this process faster.
+

--- a/fm_training_estimator/time/__init__.py
+++ b/fm_training_estimator/time/__init__.py
@@ -1,0 +1,1 @@
+from .time import get_total_time

--- a/fm_training_estimator/time/__init__.py
+++ b/fm_training_estimator/time/__init__.py
@@ -1,1 +1,2 @@
+# Local
 from .time import get_total_time

--- a/fm_training_estimator/time/time.py
+++ b/fm_training_estimator/time/time.py
@@ -1,2 +1,34 @@
-def get_total_time(tps, tokens):
-    return tokens/tps
+# Standard
+import logging
+
+# Local
+from ..config import HFTrainingArguments, InfraArguments
+from ..tokens import TokenEstimator
+
+MODEL_LOAD_TIME = 5 * 60
+CHECKPOINT_TIME = 60
+
+
+def get_total_time(
+    hf: HFTrainingArguments, ia: InfraArguments, te: TokenEstimator, tps, tokens
+):
+    train_time = tokens / tps
+
+    num_epochs = hf.num_train_epochs
+
+    # one checkpoint at the very end
+    num_checkpoints = 1
+    ss = hf.save_strategy
+    if ss == "epoch":
+        num_checkpoints += num_epochs
+    elif ss == "steps":
+        steps_in_epoch = te.get_num_samples() / (
+            hf.per_device_train_batch_size * ia.numGpusPerPod
+        )
+        num_checkpoints += num_epochs * steps_in_epoch / hf.save_steps
+    elif ss == "best":
+        logging.warn(
+            "Unable to guess number of checkpoints due to use of `best` saving strategy."
+        )
+
+    return MODEL_LOAD_TIME + train_time * num_epochs + num_checkpoints * CHECKPOINT_TIME

--- a/fm_training_estimator/time/time.py
+++ b/fm_training_estimator/time/time.py
@@ -1,0 +1,2 @@
+def get_total_time(tps, tokens):
+    return tokens/tps

--- a/fm_training_estimator/tokens/__init__.py
+++ b/fm_training_estimator/tokens/__init__.py
@@ -1,2 +1,3 @@
 # Local
+from .te import TokenEstimator
 from .te0 import TokenEstimator0

--- a/fm_training_estimator/ui/core.py
+++ b/fm_training_estimator/ui/core.py
@@ -4,6 +4,7 @@ from ..memory import HybridEstimator, HybridLoraEstimator, HybridQLoraEstimator
 from ..throughput import HybridSpeedEstimator
 from ..tokens import TokenEstimator0
 from ..utils import fmt_size
+from ..time import get_total_time
 
 
 def run(config, lookup_data_path=None, model_path=None):
@@ -62,6 +63,6 @@ def run(config, lookup_data_path=None, model_path=None):
         # get the update tps for this estimate token width
         res["tps"] = float(speed_est.get_tps(res["tokens_per_sample"]))
 
-        res["time"] = res["total_tokens"] / res["tps"]
+        res["time"] = get_total_time(res["tps"], res["total_tokens"])
 
     return res

--- a/fm_training_estimator/ui/core.py
+++ b/fm_training_estimator/ui/core.py
@@ -2,9 +2,9 @@
 from ..config import is_fsdp, parse
 from ..memory import HybridEstimator, HybridLoraEstimator, HybridQLoraEstimator
 from ..throughput import HybridSpeedEstimator
+from ..time import get_total_time
 from ..tokens import TokenEstimator0
 from ..utils import fmt_size
-from ..time import get_total_time
 
 
 def run(config, lookup_data_path=None, model_path=None):
@@ -63,6 +63,6 @@ def run(config, lookup_data_path=None, model_path=None):
         # get the update tps for this estimate token width
         res["tps"] = float(speed_est.get_tps(res["tokens_per_sample"]))
 
-        res["time"] = get_total_time(res["tps"], res["total_tokens"])
+        res["time"] = get_total_time(ta, ia, token_est, res["tps"], res["total_tokens"])
 
     return res


### PR DESCRIPTION
Add first version of total time modeling. So far, we only track single epoch training time. This PR extends it to cover other main sources of time consumption.

We have a simplistic model here by design. Follow up PRs will make the other component time break ups more realistic. For long runs (default), this should be good enough, in any case.